### PR TITLE
Add finance management routes

### DIFF
--- a/src/controllers/er/account.controller.ts
+++ b/src/controllers/er/account.controller.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from 'express';
+import { Account } from '../../models/er/account.model';
+
+export const getAllAccounts = async (_req: Request, res: Response) => {
+  const accounts = await Account.find();
+  res.json(accounts);
+};
+
+export const getAccountById = async (req: Request, res: Response) => {
+  const account = await Account.findById(req.params.id);
+  res.json(account);
+};
+
+export const createAccount = async (req: Request, res: Response) => {
+  const account = new Account(req.body);
+  await account.save();
+  res.status(201).json(account);
+};
+
+export const updateAccount = async (req: Request, res: Response) => {
+  const account = await Account.findByIdAndUpdate(req.params.id, req.body, { new: true });
+  res.json(account);
+};
+
+export const deleteAccount = async (req: Request, res: Response) => {
+  await Account.findByIdAndDelete(req.params.id);
+  res.status(204).send();
+};
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,14 @@ import employeeRoutes from "./routes/er/employee.routes";
 import attendanceRoutes from "./routes/er/attendance.routes";
 import leaveRequestRoutes from "./routes/er/leaveRequest.routes";
 import performanceGoalRoutes from "./routes/er/performanceGoal.routes";
+import accountRoutes from "./routes/er/account.routes";
+import accountPayableRoutes from "./routes/er/accountPayable.routes";
+import accountReceivableRoutes from "./routes/er/accountReceivable.routes";
+import ledgerEntryRoutes from "./routes/er/ledgerEntry.routes";
+import budgetRoutes from "./routes/er/budget.routes";
+import assetRoutes from "./routes/er/asset.routes";
+import payrollRoutes from "./routes/er/payroll.routes";
+import dashboardRoutes from "./routes/er/dashboard.routes";
 import pricingStrategyRoutes from "./routes/delivry_marketplace_v1/pricingStrategy";
 
 dotenv.config();
@@ -110,6 +118,15 @@ app.use(`${API_PREFIX}/employees`, employeeRoutes);
 app.use(`${API_PREFIX}/attendance`, attendanceRoutes);
 app.use(`${API_PREFIX}/leaves`, leaveRequestRoutes);
 app.use(`${API_PREFIX}/goals`, performanceGoalRoutes);
+// قسم الإدارة المالية
+app.use(`${API_PREFIX}/accounts`, accountRoutes);
+app.use(`${API_PREFIX}/payables`, accountPayableRoutes);
+app.use(`${API_PREFIX}/receivables`, accountReceivableRoutes);
+app.use(`${API_PREFIX}/ledger`, ledgerEntryRoutes);
+app.use(`${API_PREFIX}/budgets`, budgetRoutes);
+app.use(`${API_PREFIX}/assets`, assetRoutes);
+app.use(`${API_PREFIX}/payroll`, payrollRoutes);
+app.use(`${API_PREFIX}/dashboard`, dashboardRoutes);
 
 // قسم شحن المحفظة
 app.use(`${API_PREFIX}/topup`, topupRoutes);

--- a/src/models/er/account.model.ts
+++ b/src/models/er/account.model.ts
@@ -1,0 +1,24 @@
+import { Schema, model, Document } from 'mongoose';
+
+export interface IAccount extends Document {
+  code: string;
+  name: string;
+  type: 'asset' | 'liability' | 'equity' | 'revenue' | 'expense';
+  balance: number;
+  isActive: boolean;
+}
+
+const AccountSchema = new Schema<IAccount>({
+  code: { type: String, required: true, unique: true },
+  name: { type: String, required: true },
+  type: {
+    type: String,
+    enum: ['asset', 'liability', 'equity', 'revenue', 'expense'],
+    required: true,
+  },
+  balance: { type: Number, default: 0 },
+  isActive: { type: Boolean, default: true },
+}, { timestamps: true });
+
+export const Account = model<IAccount>('Account', AccountSchema);
+

--- a/src/routes/er/account.routes.ts
+++ b/src/routes/er/account.routes.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import {
+  getAllAccounts,
+  getAccountById,
+  createAccount,
+  updateAccount,
+  deleteAccount,
+} from '../../controllers/er/account.controller';
+
+const router = Router();
+
+router.get('/', getAllAccounts);
+router.get('/:id', getAccountById);
+router.post('/', createAccount);
+router.patch('/:id', updateAccount);
+router.delete('/:id', deleteAccount);
+
+export default router;
+


### PR DESCRIPTION
## Summary
- add Account model and controller for financial accounts
- expose account CRUD API routes
- integrate finance-related routes into the main server

## Testing
- `npm run build` *(fails: Cannot find module 'firebase-admin' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68625482a8288322be4e006eedebc94d