### PR TITLE
feat: add chart of accounts

### DIFF
--- a/src/controllers/er/chartAccount.controller.ts
+++ b/src/controllers/er/chartAccount.controller.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from 'express';
+import { ChartAccount } from '../../models/er/chartAccount.model';
+
+export const getAccounts = async (_req: Request, res: Response) => {
+  const accounts = await ChartAccount.find();
+  res.json(accounts);
+};
+
+export const getAccount = async (req: Request, res: Response) => {
+  const account = await ChartAccount.findById(req.params.id);
+  res.json(account);
+};
+
+export const createAccount = async (req: Request, res: Response) => {
+  const account = new ChartAccount(req.body);
+  await account.save();
+  res.status(201).json(account);
+};
+
+export const updateAccount = async (req: Request, res: Response) => {
+  const updated = await ChartAccount.findByIdAndUpdate(req.params.id, req.body, { new: true });
+  res.json(updated);
+};
+
+export const deleteAccount = async (req: Request, res: Response) => {
+  await ChartAccount.findByIdAndDelete(req.params.id);
+  res.status(204).send();
+};
+
+export const getAccountTree = async (_req: Request, res: Response) => {
+  const accounts = await ChartAccount.find().lean();
+  const map = new Map<string, any>();
+  accounts.forEach((acc: any) => {
+    map.set(acc._id.toString(), { ...acc, children: [] });
+  });
+  const roots: any[] = [];
+  map.forEach((acc) => {
+    if (acc.parent) {
+      const parent = map.get(acc.parent.toString());
+      if (parent) parent.children.push(acc);
+    } else {
+      roots.push(acc);
+    }
+  });
+  res.json(roots);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import pricingStrategyRoutes from "./routes/delivry_marketplace_v1/pricingStrate
 import deliveryPromotionRoutes from "./routes/delivry_marketplace_v1/promotion.routes";
 import groceriesRoutes from "./routes/marchent/api";
 import storeSectionRoutes from "./routes/delivry_marketplace_v1/storeSection.routes";
+import chartAccountRoutes from "./routes/er/chartAccount.routes";
 
 dotenv.config();
 
@@ -110,6 +111,7 @@ app.use(`${API_PREFIX}/employees`, employeeRoutes);
 app.use(`${API_PREFIX}/attendance`, attendanceRoutes);
 app.use(`${API_PREFIX}/leaves`, leaveRequestRoutes);
 app.use(`${API_PREFIX}/goals`, performanceGoalRoutes);
+app.use(`${API_PREFIX}/accounts/chart`, chartAccountRoutes);
 app.use(`${API_PREFIX}/admin/notifications`, adminNotificationRoutes);
 // قسم شحن المحفظة
 app.use(`${API_PREFIX}/topup`, topupRoutes);

--- a/src/models/er/chartAccount.model.ts
+++ b/src/models/er/chartAccount.model.ts
@@ -1,0 +1,21 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IChartAccount extends Document {
+  name: string;
+  code: string;
+  type: 'asset' | 'liability' | 'equity' | 'revenue' | 'expense';
+  parent?: Types.ObjectId | null;
+}
+
+const ChartAccountSchema = new Schema<IChartAccount>({
+  name: { type: String, required: true },
+  code: { type: String, required: true, unique: true },
+  type: {
+    type: String,
+    enum: ['asset', 'liability', 'equity', 'revenue', 'expense'],
+    required: true,
+  },
+  parent: { type: Schema.Types.ObjectId, ref: 'ChartAccount', default: null },
+}, { timestamps: true });
+
+export const ChartAccount = model<IChartAccount>('ChartAccount', ChartAccountSchema);

--- a/src/routes/er/chartAccount.routes.ts
+++ b/src/routes/er/chartAccount.routes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  getAccounts,
+  getAccount,
+  createAccount,
+  updateAccount,
+  deleteAccount,
+  getAccountTree,
+} from '../../controllers/er/chartAccount.controller';
+
+const router = Router();
+router.get('/', getAccounts);
+router.get('/tree', getAccountTree);
+router.get('/:id', getAccount);
+router.post('/', createAccount);
+router.patch('/:id', updateAccount);
+router.delete('/:id', deleteAccount);
+export default router;


### PR DESCRIPTION
## Summary
- add MongoDB schema for chart of accounts with hierarchy
- expose CRUD and tree endpoints for chart accounts
- wire chart accounts routes into main API

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68934c6c85588328854a99a430e969c0